### PR TITLE
Book external url

### DIFF
--- a/src/tutorials.html
+++ b/src/tutorials.html
@@ -68,7 +68,7 @@ books:
 						<div class="col-4 ani-sfb" data-delay="0.2" data-speed="0.5" data-animation="short-from-bottom">
 							<div class="books">
                                 {% for book in page.books %}
-								<a href="{{ book.url }}" target="_blank" class="book-{{ forloop.index }}">
+								<a href="{{ book.external_url }}" target="_blank" class="book-{{ forloop.index }}">
 									<h4>Book</h4>
 									<h6 class="mono">{{ book.title }}</h6>
 									<p class="mono author">_by {{ book.author }}</p>


### PR DESCRIPTION
On the [tutorials page](https://pixijs.com/tutorials/), the _Learn Pixi.js_ book by Rex van der Spuy link reloads the page instead of navigating to the book url.

The href is invalid:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1213591/160266256-2dceec88-93c0-41d7-a47f-def69d922862.png">

I believe it should be referencing `external_url` instead of `url`.

As an aside, I worked on that book with Rex through Apress / Springer Science + Business Media as the technical reviewer - back in 2015, if I recall.  You can find me in the front matter of that publication.
